### PR TITLE
"چ" letter bug patch

### DIFF
--- a/lib/persian-bechasboon/core.rb
+++ b/lib/persian-bechasboon/core.rb
@@ -77,8 +77,8 @@ module PersianBechasboon
     add("067e", "fb56", "fb57", "fb58", "fb59", true)  # pe
     add("062a", "fe95", "fe96", "fe97", "fe98", true)  # Ta2
     add("062b", "fe99", "fe9a", "fe9b", "fe9c", true)  # Tha2
-    add("062c", "fe9d", "fe9e", "fe9f", "fea0", true)  # Jeem
-    add("fb7a", "0868", "fb7b", "fb7c", "fb7d", true)  # che
+    add("062c", "fe9d", "fe9e", "fe9f", "fea0", true)  # Jeem   
+    add("0686", "fb7a", "fb7b", "fb7c", "fb7d", true)  # che    
     add("062d", "fea1", "fea2", "fea3", "fea4", true)  # 7a2
     add("062e", "fea5", "fea6", "fea7", "fea8", true)  # 7'a2
     add("062f", "fea9", "feaa", "fea9", "feaa", false) # Dal

--- a/lib/persian-bechasboon/core.rb
+++ b/lib/persian-bechasboon/core.rb
@@ -77,8 +77,8 @@ module PersianBechasboon
     add("067e", "fb56", "fb57", "fb58", "fb59", true)  # pe
     add("062a", "fe95", "fe96", "fe97", "fe98", true)  # Ta2
     add("062b", "fe99", "fe9a", "fe9b", "fe9c", true)  # Tha2
-    add("062c", "fe9d", "fe9e", "fe9f", "fea0", true)  # Jeem   
-    add("0686", "fb7a", "fb7b", "fb7c", "fb7d", true)  # che    
+    add("062c", "fe9d", "fe9e", "fe9f", "fea0", true)  # Jeem
+    add("0686", "fb7a", "fb7b", "fb7c", "fb7d", true)  # che
     add("062d", "fea1", "fea2", "fea3", "fea4", true)  # 7a2
     add("062e", "fea5", "fea6", "fea7", "fea8", true)  # 7'a2
     add("062f", "fea9", "feaa", "fea9", "feaa", false) # Dal


### PR DESCRIPTION
Hello, I'd want to express my gratitude for this wonderful code. It's easy to use and has been correctly adapted into Farsi. This branch has been updated to fix a minor issue with the "چ" letter. (the character was defined as "0868", However the correct is "0686")

THANK YOU AGAIN for shifting focus to the absurd lack of support for the language, which has more than 150 million native speakers worldwide. The Persian community deserves SO MUCH MORE support.